### PR TITLE
Update specswa.m - BUG FIX

### DIFF
--- a/code/package/swa/specswa.m
+++ b/code/package/swa/specswa.m
@@ -156,7 +156,7 @@ while (revmin > 0 && winwidth < 99)
         end
     end
     
-    if(revmin == 0)
+    if(revmin <= rev1 && revmin <= rev2) % BUG FIX - HY ZHU, 27 NOV 2023
         if(rmsemin > rmsef1)
             rmsemin=rmsef1;
             winfinal=winwidth;


### PR DESCRIPTION
The SWA Program may crash if `revmin <= rev1 && revmin <= rev2` so `revmin` remains original.
This bug was detected by Hanyu Zhu during a MT SWA analysis on a hi-res data (~7 m / 1 mm).

Code modification:
specswa.m - Line 159
Fixed an "ignored" condition: `revmin` remains original.